### PR TITLE
Missing arrow module in requirements.txt on Linux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # to run this project. Later you can install all these apps in a row
 # using pip. Example:
 #
-#     pip install -r REQUIREMENTS.txt
+#     pip install -r requirements.txt
 #
 
 # before install python dependencies, you need the ppa ubuntugis activated and some libraries installed on your os:
@@ -22,3 +22,4 @@ pytz
 requests
 six
 xlwt
+arrow


### PR DESCRIPTION
I could'nt install on Linux because the arrow module was not in the requirements.txt file.
I've added it.