### PR TITLE
refacto: remove OrderedDict

### DIFF
--- a/dicogis/DicoGIS.py
+++ b/dicogis/DicoGIS.py
@@ -19,7 +19,6 @@ import getpass
 import locale
 import logging
 import platform
-from collections import OrderedDict
 from logging.handlers import RotatingFileHandler
 from os import path, walk
 from pathlib import Path
@@ -150,7 +149,7 @@ class DicoGIS(ThemedTk):
         self.def_lang = "EN"  # default language to start
         self.today = strftime("%Y-%m-%d")  # date of the day
         li_lang = [lg.name[5:-4] for lg in dir_locale.glob("*.xml")]  # languages
-        self.blabla = OrderedDict()  # texts dictionary
+        self.blabla = {}  # texts dictionary
 
         # formats / type: vectors
         self.li_vectors_formats = (
@@ -181,16 +180,16 @@ class DicoGIS(ThemedTk):
         self.li_dgn = []  # list for MicroStation DGN paths
 
         # dictionaries to store informations
-        self.dico_layer = OrderedDict()  # dict for vectors informations
-        self.dico_fields = OrderedDict()  # dict for fields informations
-        self.dico_raster = OrderedDict()  # dict for rasters global informations
-        self.dico_bands = OrderedDict()  # dict for bands informations
-        self.dico_fdb = OrderedDict()  # dict for Esri FileGDB
-        self.dico_cdao = OrderedDict()  # dict for CAO/DAO
-        self.dico_err = OrderedDict()  # errors list
+        self.dico_layer = {}  # dict for vectors informations
+        self.dico_fields = {}  # dict for fields informations
+        self.dico_raster = {}  # dict for rasters global informations
+        self.dico_bands = {}  # dict for bands informations
+        self.dico_fdb = {}  # dict for Esri FileGDB
+        self.dico_cdao = {}  # dict for CAO/DAO
+        self.dico_err = {}  # errors list
 
         # metrics
-        self.dico_metrics = OrderedDict()
+        self.dico_metrics = {}
         self.global_total_layers = 0
         self.global_total_fields = 0
         self.global_total_features = 0
@@ -200,7 +199,7 @@ class DicoGIS(ThemedTk):
         self.global_total_srs_geog = 0
         self.global_total_srs_none = 0
         self.global_ignored = 0  # files ignored by an user filter
-        self.global_dico_fields = OrderedDict()
+        self.global_dico_fields = {}
 
         # Notebook
         self.nb = Notebook(self)
@@ -1241,7 +1240,7 @@ class DicoGIS(ThemedTk):
         """Test database connection and handling specific
         settings : proxy, DB views, etc.
         """
-        self.dico_dataset = OrderedDict()
+        self.dico_dataset = {}
         # check if a proxy is needed
         # more information about the GDAL HTTP proxy options here:
         # http://trac.osgeo.org/gdal/wiki/ConfigOptions#GDALOGRHTTPoptions

--- a/dicogis/georeaders/Infos_DXF.py
+++ b/dicogis/georeaders/Infos_DXF.py
@@ -15,7 +15,6 @@
 
 # Standard library
 import logging
-from collections import OrderedDict
 from os import chdir, path
 from time import localtime, strftime
 
@@ -145,7 +144,7 @@ class ReadDXF:
         # parsing layers
         for layer_idx in range(src.GetLayerCount()):
             # dictionary where will be stored informations
-            dico_layer = OrderedDict()
+            dico_layer = {}
             dico_layer["src_name"] = dico_dataset.get("name")
             # getting layer object
             layer = src.GetLayerByIndex(layer_idx)
@@ -217,7 +216,7 @@ if __name__ == "__main__":
     """standalone execution for tests. Paths are relative considering a test
     within the official repository (https://github.com/Guts/DicoGIS/)"""
     # test text dictionary
-    textos = OrderedDict()
+    textos = {}
     textos["srs_comp"] = "Compound"
     textos["srs_geoc"] = "Geocentric"
     textos["srs_geog"] = "Geographic"
@@ -233,7 +232,7 @@ if __name__ == "__main__":
     li_dxf = [r"..\..\test\datatest\cao\dxf\paris_transports_ed.dxf"]
 
     # recipient datas
-    dico_dataset = OrderedDict()
+    dico_dataset = {}
 
     # read DXF
     for source_path in li_dxf:

--- a/dicogis/georeaders/Infos_GDB.py
+++ b/dicogis/georeaders/Infos_GDB.py
@@ -15,7 +15,6 @@
 # #################################
 # Standard library
 import logging
-from collections import OrderedDict
 from os import path, walk
 from time import localtime, strftime
 
@@ -114,7 +113,7 @@ class ReadGDB:
         # parsing layers
         for layer_idx in range(src.GetLayerCount()):
             # dictionary where will be stored informations
-            dico_layer = OrderedDict()
+            dico_layer = {}
             # parent GDB
             dico_layer["src_name"] = path.basename(src.GetName())
             # getting layer object
@@ -190,7 +189,7 @@ if __name__ == "__main__":
     # sample files
     chdir(r"..\..\test\datatest\FileGDB\Esri_FileGDB")
     # test text dictionary
-    textos = OrderedDict()
+    textos = {}
     textos["srs_comp"] = "Compound"
     textos["srs_geoc"] = "Geocentric"
     textos["srs_geog"] = "Geographic"
@@ -225,7 +224,7 @@ if __name__ == "__main__":
                 pass
 
     # recipient datas
-    dico_dataset = OrderedDict()
+    dico_dataset = {}
     gdbReader = ReadGDB()
 
     # read GDB

--- a/dicogis/georeaders/Infos_PostGIS.py
+++ b/dicogis/georeaders/Infos_PostGIS.py
@@ -17,7 +17,6 @@
 import logging
 
 # Standard library
-from collections import OrderedDict
 
 # 3rd party libraries
 try:
@@ -59,7 +58,7 @@ class ReadPostGIS:
         user="postgres",
         password="postgres",
         views_included=1,
-        dico_dataset=OrderedDict(),
+        dico_dataset={},
         txt={},
     ):
         """Uses gdal/ogr functions to extract basic informations about
@@ -247,7 +246,7 @@ if __name__ == "__main__":
     # libraries import
 
     # test text dictionary
-    textos = OrderedDict()
+    textos = {}
     textos["srs_comp"] = "Compound"
     textos["srs_geoc"] = "Geocentric"
     textos["srs_geog"] = "Geographic"
@@ -267,7 +266,7 @@ if __name__ == "__main__":
         test_host, test_db, test_user, test_pwd
     )
     # use reader
-    dico_dataset = OrderedDict()
+    dico_dataset = {}
     pgReader = ReadPostGIS(
         host=test_host,
         port=5432,

--- a/dicogis/georeaders/Infos_Rasters.py
+++ b/dicogis/georeaders/Infos_Rasters.py
@@ -16,7 +16,6 @@
 # #################################
 # Standard library
 import logging
-from collections import OrderedDict
 from os import chdir, path
 from time import localtime, strftime
 
@@ -376,7 +375,7 @@ if __name__ == "__main__":
     )
 
     # test text dictionary
-    textos = OrderedDict()
+    textos = {}
     textos["srs_comp"] = "Compound"
     textos["srs_geoc"] = "Geocentric"
     textos["srs_geog"] = "Geographic"
@@ -391,8 +390,8 @@ if __name__ == "__main__":
     for raster in li_rasters:
         """looping on raster files"""
         # recipient datas
-        dico_raster = OrderedDict()  # dictionary where will be stored informations
-        dico_bands = OrderedDict()  # dictionary for fields information
+        dico_raster = {}  # dictionary where will be stored informations
+        dico_bands = {}  # dictionary for fields information
         # getting the informations
         if not path.isfile(raster):
             print("\n\t==> File doesn't exist: " + raster)

--- a/dicogis/georeaders/Infos_Spatialite.py
+++ b/dicogis/georeaders/Infos_Spatialite.py
@@ -15,7 +15,6 @@
 # #################################
 # Standard library
 import logging
-from collections import OrderedDict
 from os import path
 from time import localtime, strftime
 
@@ -133,7 +132,7 @@ class ReadSpaDB:
         # parsing layers
         for layer_idx in range(spadb.GetLayerCount()):
             # dictionary where will be stored informations
-            dico_layer = OrderedDict()
+            dico_layer = {}
             # parent GDB
             dico_layer["gdb_name"] = path.basename(spadb.GetName())
             # getting layer object
@@ -181,7 +180,7 @@ class ReadSpaDB:
             self.infos_geos(layer_obj, srs, dico_layer, txt)
 
         # getting fields informations
-        dico_fields = OrderedDict()
+        dico_fields = {}
         layer_def = layer_obj.GetLayerDefn()
         dico_layer["num_fields"] = layer_def.GetFieldCount()
         self.infos_fields(layer_def, dico_fields)

--- a/dicogis/georeaders/Infos_VectorFlatDataset.py
+++ b/dicogis/georeaders/Infos_VectorFlatDataset.py
@@ -15,7 +15,6 @@
 
 # Standard library
 import logging
-from collections import OrderedDict
 from os import path
 from time import localtime, strftime
 
@@ -186,7 +185,7 @@ if __name__ == "__main__":
         path.realpath(r"..\..\test\datatest\vectors\kml\PPRI_Loire_sept2014.kmz"),
     ]
     # test text dictionary
-    textos = OrderedDict()
+    textos = {}
     textos["srs_comp"] = "Compound"
     textos["srs_geoc"] = "Geocentric"
     textos["srs_geog"] = "Geographic"
@@ -197,7 +196,7 @@ if __name__ == "__main__":
     textos["geom_ligne"] = "Line"
     textos["geom_polyg"] = "Polygon"
     # recipient datas
-    dico_dataset = OrderedDict()  # dictionary where will be stored info
+    dico_dataset = {}  # dictionary where will be stored info
     # execution
     for vector in li_vectors:
         """looping on shapefiles list"""

--- a/dicogis/georeaders/geo_infos_generic.py
+++ b/dicogis/georeaders/geo_infos_generic.py
@@ -7,7 +7,6 @@
 
 # Standard library
 import logging
-from collections import OrderedDict
 
 # 3rd party libraries
 try:
@@ -48,7 +47,7 @@ class GeoInfosGenericReader:
 
     def get_fields_details(self, layer_def) -> dict:
         """Get fields definition."""
-        dico_fields = OrderedDict()
+        dico_fields = {}
         for i in range(layer_def.GetFieldCount()):
             field = layer_def.GetFieldDefn(i)  # fields ordered
             dico_fields[field.GetName()] = (


### PR DESCRIPTION
https://realpython.com/python-ordereddict/#choosing-between-ordereddict-and-dict

> Python 3.6 introduced a [new implementation of dict](https://docs.python.org/3/whatsnew/3.6.html#new-dict-implementation). This new implementation represents a big win in terms of memory usage and iteration efficiency. Additionally, the new implementation provides a new and somewhat unexpected feature: dict objects now keep their items in the same order they were introduced. Initially, this feature was considered an implementation detail, and the documentation advised against relying on it.