### PR TITLE
packaging: use distro.id instead of distro.name to avoid special chars

### DIFF
--- a/builder/pyinstaller_build_ubuntu.py
+++ b/builder/pyinstaller_build_ubuntu.py
@@ -39,7 +39,7 @@ PyInstaller.__main__.run(
         "--name={}_{}_{}{}_{}_Python{}".format(
             __about__.__title_clean__,
             __about__.__version__,
-            distro.name(),
+            distro.id(),
             distro.version(),
             platform.architecture()[0],
             platform.python_version(),


### PR DESCRIPTION
Since on Debian:

```python
>>> import distro
>>> distro.name()
'Debian GNU/Linux'
```