### PR TITLE
CI: use gdal 3.8.x for packaging

### DIFF
--- a/.github/workflows/builder_releaser.yml
+++ b/.github/workflows/builder_releaser.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      GDAL_VERSION: 3.6.*
+      GDAL_VERSION: 3.8.*
 
     steps:
       - name: Get source code

--- a/.github/workflows/builder_releaser.yml
+++ b/.github/workflows/builder_releaser.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on: windows-latest
 
     env:
-      GDAL_VERSION: 3.6.4
+      GDAL_VERSION: 3.8.4
 
     steps:
       - name: Get source code
@@ -107,7 +107,7 @@ jobs:
         run: |
           python -m pip install -U pip setuptools wheel
           python -m pip install -U -r requirements/base.txt
-          python -m pip install -U https://github.com/cgohlke/geospatial-wheels/releases/download/v2023.4.22/GDAL-3.6.4-cp310-cp310-win_amd64.whl
+          python -m pip install -U https://github.com/cgohlke/geospatial-wheels/releases/download/v2024.2.18/GDAL-3.8.4-cp310-cp310-win_amd64.whl
           python -m pip install -U -r requirements/packaging.txt
 
       - name: Install project as a package


### PR DESCRIPTION
Mainly because GDAL 3.6 is no longer available in ubuntugis-unstable: https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable