### PR TITLE
update(chore): bump minimal typer version to handle click 8.2+

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
       interval: monthly
       time: "20:00"
       timezone: Europe/Paris
-    assignees:
-      - guts
     labels:
       - dependencies
 
@@ -15,7 +13,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    assignees:
-      - guts
     labels:
       - ci-cd

--- a/.github/workflows/tester_ubuntu.yml
+++ b/.github/workflows/tester_ubuntu.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - ".github/workflows/tester_ubuntu.yml"
       - "**/*.py"
+      - pyproject.toml
 
   pull_request:
     branches:
@@ -15,6 +16,7 @@ on:
     paths:
       - ".github/workflows/tester_ubuntu.yml"
       - "**/*.py"
+      - pyproject.toml
 
 
 env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,7 @@ dependencies = [
     "pgserviceparser>=2.4,<3",
     "requests>=2.32.3,<3",
     "ttkthemes>=3.2.2,<3.3",
-    "typer>=0.15.3,<1",
-    # constraints
-    "click<8.2.0", # see https://github.com/Guts/DicoGIS/pull/375
+    "typer>=0.16.0,<1",
 ]
 
 version = "4.0.0-beta10"


### PR DESCRIPTION
Revert https://github.com/Guts/DicoGIS/pull/375 thanks to https://github.com/fastapi/typer/releases/tag/0.16.0